### PR TITLE
Fix clock_gettime for Apple clang

### DIFF
--- a/agrpc/base/chrono.cc
+++ b/agrpc/base/chrono.cc
@@ -28,7 +28,7 @@ namespace {
 template <class T>
 inline T ReadClock(int type) {
   timespec ts;
-  clock_gettime(type, &ts);
+  clock_gettime(static_cast<clockid_t>(type), &ts);
   return T((ts.tv_sec * 1'000'000'000LL + ts.tv_nsec) * 1ns);
 }
 


### PR DESCRIPTION
The PR fixes `clock_gettime` lack of type conversion error for `Apple clang version 13.1.6 (clang-1316.0.21.2.5)`:

```
/Users/genertorg/git/agrpc/agrpc/base/chrono.cc:31:3: error: no matching function for call to 'clock_gettime'
  clock_gettime(type, &ts);
  ^~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/time.h:178:5: note: candidate function not viable: no known conversion from 'int' to 'clockid_t' for 1st argument
int clock_gettime(clockid_t __clock_id, struct timespec *__tp);
    ^
1 error generated.
make[2]: *** [agrpc/base/CMakeFiles/agrpc_base_chrono.dir/chrono.cc.o] Error 1
make[1]: *** [agrpc/base/CMakeFiles/agrpc_base_chrono.dir/all] Error 2
```

